### PR TITLE
Fixing the repeated closing-a-toast bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butter-toast",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Smooth toast notifications for react apps",
   "keywords": [
     "React notifications",

--- a/src/Toast/index.js
+++ b/src/Toast/index.js
@@ -66,6 +66,7 @@ class Toast extends Component {
     }
 
     close = () => {
+        if (this.state.removed) return;
         const toastRef = this.toastRef;
         this.clearTimeout();
 

--- a/src/Toast/index.js
+++ b/src/Toast/index.js
@@ -66,7 +66,11 @@ class Toast extends Component {
     }
 
     close = () => {
-        if (this.state.removed) return;
+
+        if (this.state.removed) {
+            return;
+        }
+
         const toastRef = this.toastRef;
         this.clearTimeout();
 


### PR DESCRIPTION
Googling around this type of issue I found that:

> The solution is to check the state immediately upon entry to the handler. React guarantees that setState inside interactive events (such as click) is flushed at browser event boundary.

So I added a state check inside the handler.
Tested and seems to be working fine.

Refs: [Link](https://stackoverflow.com/a/49642037), [Link2](https://github.com/facebook/react/issues/11171#issuecomment-357945371).