### PR TITLE
fix for IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "butter-toast",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
         filename: '[name].js',
         libraryTarget: 'umd',
         path: path.resolve(__dirname, 'dist'),
-        globalObject: '((() => 0).constructor("return this"))()'
+        globalObject: '((function f() { return 0; }).constructor("return this"))()'
     },
     module: {
         rules: [{


### PR DESCRIPTION
the arrow function injected through globalObject doesn't get transpile to ES5 compliant code.